### PR TITLE
Fix host url messaging

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2015-12-14  Nik Nyby  <nnyby@columbia.edu>
+
+	* Fix host url messaging.
+
 2015-12-08  Nik Nyby  <nnyby@columbia.edu>
 
 	* Update CSS file and fix mediathread logo path.

--- a/data/src/init.js
+++ b/data/src/init.js
@@ -7,6 +7,8 @@ $.ajax({
         withCredentials: true
     },
     success: function(d) {
+        var hostUrl = MediathreadCollectOptions.host_url.replace(
+                /\/save\/$/, '');
         if ('flickr_apikey' in d) {
             MediathreadCollect.options.flickr_apikey = d.flickr_apikey;
         }
@@ -20,14 +22,13 @@ $.ajax({
                 MediathreadCollectOptions.host_url, true);
         } else if (d.logged_in === true && d.course_selected === false) {
             alert(
-                'You\'re logged in to mediathread at ' +
-                    MediathreadCollectOptions.host_url +
-                    ', now select a course to use the browser extension.');
+                'You\'re logged in to Mediathread at ' +
+                    hostUrl +
+                    ', now select a course to use the Firefox extension.');
         } else {
             alert(
-                'Log in to mediathread (' +
-                    MediathreadCollectOptions.host_url +
-                    ') and select a course!');
+                'Log in to Mediathread here: ' + hostUrl +
+                    ' and select a course!');
         }
     },
     error: function(d) {


### PR DESCRIPTION
The host url is the mediathread url plus `/save/`. Instead of changing
that part, since the code in collect.js relies on it, I'm fixing the url
when displaying it to the user.
